### PR TITLE
Fix issues #47 and #51

### DIFF
--- a/src/main/java/com/meti/client/ClientCreator.java
+++ b/src/main/java/com/meti/client/ClientCreator.java
@@ -3,12 +3,6 @@ package com.meti.client;
 import com.meti.util.Dialog;
 import com.meti.util.LoggerHandler;
 import com.meti.util.Utility;
-import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
-import javafx.fxml.Initializable;
-import javafx.scene.Parent;
-import javafx.scene.control.TextField;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -19,6 +13,12 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.Initializable;
+import javafx.scene.Parent;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
 
 public class ClientCreator implements Initializable {
 
@@ -53,11 +53,11 @@ public class ClientCreator implements Initializable {
             Parent parent = loader.load();
             ClientDisplay display = loader.getController();
 
-            Utility.buildStage(parent);
+            Stage stage = Utility.buildStage(parent);
             //consider creating client class
             display.setSocket(socket);
             display.setHandler(clientHandler);
-
+            display.setStage(stage);
             display.init();
         } catch (Exception e) {
             try {

--- a/src/main/java/com/meti/client/ClientDisplay.java
+++ b/src/main/java/com/meti/client/ClientDisplay.java
@@ -19,6 +19,7 @@ import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.stage.Stage;
 
 public class ClientDisplay implements Initializable {
 
@@ -36,8 +37,8 @@ public class ClientDisplay implements Initializable {
   private Socket socket;
   private ClientHandler handler;
   private TreeItem<String> root = new TreeItem<>();
+  private Stage stage;
 
-  @FXML
   public void close() {
     try {
       socket.close();
@@ -49,6 +50,11 @@ public class ClientDisplay implements Initializable {
 
     //concerning exit statement
     System.exit(0);
+  }
+
+  @FXML
+  public void onCloseMenuItemClicked() {
+    stage.close();
   }
 
   @FXML
@@ -118,6 +124,11 @@ public class ClientDisplay implements Initializable {
 
   public void setHandler(ClientHandler handler) {
     this.handler = handler;
+  }
+
+  public void setStage(Stage stage) {
+    this.stage = stage;
+    stage.setOnCloseRequest(event -> close());
   }
 
   @Override

--- a/src/main/java/com/meti/server/ServerCreator.java
+++ b/src/main/java/com/meti/server/ServerCreator.java
@@ -40,6 +40,7 @@ public class ServerCreator {
 
       Scene scene = new Scene(parent);
       Stage stage = new Stage();
+      display.setStage(stage);
       stage.setScene(scene);
       stage.show();
 

--- a/src/main/java/com/meti/server/ServerDisplay.java
+++ b/src/main/java/com/meti/server/ServerDisplay.java
@@ -9,6 +9,7 @@ import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
 import javafx.scene.text.Text;
+import javafx.stage.Stage;
 
 public class ServerDisplay {
 
@@ -25,13 +26,20 @@ public class ServerDisplay {
   private Text portText;
 
   private Server server;
+  private Stage stage;
 
-  @FXML
+  /**
+   * Invoked upon stage close request.
+   */
   public void close() {
     server.stop();
-
     Platform.exit();
     System.exit(0);
+  }
+
+  @FXML
+  public void onCloseMenuItemClicked() {
+    stage.close();
   }
 
   public void buildListeners() {
@@ -49,6 +57,11 @@ public class ServerDisplay {
     this.server = server;
 
     portText.setText(String.valueOf(server.getServerSocket().getLocalPort()));
+  }
+
+  public void setStage(Stage stage) {
+    this.stage = stage;
+    stage.setOnCloseRequest(event -> close());
   }
 
   private class TextAreaHandler extends Handler {

--- a/src/main/resources/fxml/ClientDisplay.fxml
+++ b/src/main/resources/fxml/ClientDisplay.fxml
@@ -20,7 +20,7 @@
           <menus>
             <Menu mnemonicParsing="false" text="File">
               <items>
-                <MenuItem mnemonicParsing="false" onAction="#close" text="Close"/>
+                <MenuItem mnemonicParsing="false" onAction="#onCloseMenuItemClicked" text="Close"/>
               </items>
             </Menu>
             <Menu mnemonicParsing="false" text="Edit">

--- a/src/main/resources/fxml/ServerDisplay.fxml
+++ b/src/main/resources/fxml/ServerDisplay.fxml
@@ -25,7 +25,7 @@
           <menus>
             <Menu mnemonicParsing="false" text="File">
               <items>
-                <MenuItem mnemonicParsing="false" onAction="#close" text="Close"/>
+                <MenuItem mnemonicParsing="false" onAction="#onCloseMenuItemClicked" text="Close"/>
               </items>
             </Menu>
             <Menu mnemonicParsing="false" text="Edit">


### PR DESCRIPTION
This pull request fixes the issues #47 and #51 that caused program not to terminate when window closes.

Server and client were never closed because `close()` method was invoked _only_ on the menu item click event. The window close button only closed the window, the background processes weren't closed. This pull request sets the same functionality on window close button and the close menu item - whichever you press, the window and processes will be closed.
